### PR TITLE
Adding rockspec for installation via LuaRocks

### DIFF
--- a/lua-resty-iputils-0.1.0-1.rockspec
+++ b/lua-resty-iputils-0.1.0-1.rockspec
@@ -1,0 +1,23 @@
+package = "lua-resty-iputils"
+version = "0.1.0-1"
+
+source = {
+  url = "git://github.com/hamishforbes/lua-resty-iputils.git",
+  tag = "v0.1.0",
+}
+
+description = {
+  summary = "Utility functions for working with IP addresses in Openresty",
+  license = "MIT",
+}
+
+dependencies = {
+  "lua >= 5.1",
+}
+
+build = {
+  type = "builtin",
+  modules = {
+    ["resty.iputils"] = "lib/resty/iputils.lua",
+  },
+}


### PR DESCRIPTION
This adds a rockspec file so this module can be installed via LuaRocks. If you're interested in this, I think you'll just need to add the "v0.1.0" tag to your repository (or adjust the version numbers in the rockspec file if you'd prefer a different version number). Then if you wanted to publish this to the default MoonRocks repo, you'd need to upload it there (see [Get Started](https://rocks.moonscript.org)).

Thanks for providing the library, it's super handy!