### PR TITLE
Requiring resty.lrucache only if lrucache has been enabled

### DIFF
--- a/lib/resty/iputils.lua
+++ b/lib/resty/iputils.lua
@@ -12,7 +12,6 @@ local byte       = string.byte
 local str_find   = string.find
 local str_sub    = string.sub
 
-local resty_lrucache = require "resty.lrucache"
 local lrucache = nil
 
 local _M = {
@@ -36,6 +35,7 @@ end
 
 
 local function enable_lrucache(size)
+    local resty_lrucache = require "resty.lrucache"
     local size = size or 4000  -- Cache the last 4000 IPs (~1MB memory) by default
     local lrucache_obj, err = resty_lrucache.new(4000)
     if not lrucache_obj then

--- a/lib/resty/iputils.lua
+++ b/lib/resty/iputils.lua
@@ -1,7 +1,4 @@
 local ipairs, unpack, tonumber, tostring, type = ipairs, unpack, tonumber, tostring, type
-local ngx        = ngx
-local ngx_log    = ngx.log
-local ngx_ERR    = ngx.ERR
 local bit        = require("bit")
 local tobit      = bit.tobit
 local lshift     = bit.lshift
@@ -151,7 +148,9 @@ local function parse_cidrs(cidrs)
     for _,cidr in ipairs(cidrs) do
         local lower, upper = parse_cidr(cidr)
         if not lower then
-            ngx_log(ngx_ERR, "Error parsing '", cidr, "': ", upper)
+            if ngx then
+                ngx.log(ngx.ERR, "Error parsing '", cidr, "': ", upper)
+            end
         else
             out[i] = {lower, upper}
             i = i+1


### PR DESCRIPTION
This is a small fix that will require `resty.lrucache` only if the cache has been enabled with `iputils.enable_lrucache()`.

This PR will avoid including a dependency that might not be used, but most importantly it will make the library work in environments other than OpenResty if the cache is being disabled.