### PR TITLE
Update 01-ip2bin.t

### DIFF
--- a/t/01-ip2bin.t
+++ b/t/01-ip2bin.t
@@ -8,7 +8,7 @@ my $pwd = cwd();
 $ENV{TEST_LEDGE_REDIS_DATABASE} ||= 1;
 
 our $HttpConfig = qq{
-    lua_package_path "$pwd/lib/?.lua;;";
+    lua_package_path "$pwd/lib/?.lua;../lua-resty-lrucache/lib/?.lua;;";
 };
 
 no_long_string();


### PR DESCRIPTION
Fix lua-resty-lrucache dependency, such that the line 217 `iputils.enable_lrucache(100)` won't fault a error