### PR TITLE
rockspec: use git+https:// for git repository URL

### DIFF
--- a/lua-resty-iputils-0.3.0-1.rockspec
+++ b/lua-resty-iputils-0.3.0-1.rockspec
@@ -2,7 +2,7 @@ package = "lua-resty-iputils"
 version = "0.3.0-1"
 
 source = {
-  url = "git://github.com/hamishforbes/lua-resty-iputils.git",
+  url = "git+https://github.com/hamishforbes/lua-resty-iputils.git",
   tag = "v0.3.0",
 }
 


### PR DESCRIPTION
GitHub disabled unencrypted Git protocol, so `git://` URLs will not work anymore (see [1](https://github.blog/2021-09-01-improving-git-protocol-security-github/))

Fix #24 